### PR TITLE
Add empty events object to proxy contract example

### DIFF
--- a/admin-events/agent-config.json.example
+++ b/admin-events/agent-config.json.example
@@ -27,7 +27,8 @@
     "contractName3": {
       "address": "contractAddress3",
       "abiFile": "filename3.json",
-      "proxy": "contractName2"
+      "proxy": "contractName2",
+      "events": {}
     }
   }
 }


### PR DESCRIPTION
The admin events' test fails if the events object is not defined for a proxy contract. 

```javascript
check agent configuration file › contracts key values must be valid

    TypeError: Cannot convert undefined or null to object
        at Function.keys (<anonymous>)

      58 |       // for all of the events specified, verify that they exist in the ABI
    > 59 |       Object.keys(events).forEach((eventName) => {
         |              ^
      60 |         expect(Object.keys(eventObjects).indexOf(eventName)).not.toBe(-1);
```
Adding an empty `events` object to prevent `TypeError` error from object conversion on undefined events.
https://github.com/arbitraryexecution/forta-agent-templates/blob/main/admin-events/src/agent.spec.js#L58