### PR TITLE
AE-1271: Fixing admin events agent test script for proxy contracts without events specified

### DIFF
--- a/admin-events/src/utils.js
+++ b/admin-events/src/utils.js
@@ -1,6 +1,10 @@
 const BigNumber = require('bignumber.js');
 const { ethers } = require('forta-agent');
 
+function isEmpty(object) {
+  return Object.keys(object).length === 0;
+}
+
 function getAbi(abiName) {
   // eslint-disable-next-line global-require,import/no-dynamic-require
   const { abi } = require(`../abi/${abiName}`);
@@ -153,6 +157,7 @@ function checkLogAgainstExpression(expressionObject, log) {
 }
 
 module.exports = {
+  isEmpty,
   getAbi,
   extractEventArgs,
   isNumeric,


### PR DESCRIPTION
This work addresses the issue specified in pull request #20 , where a contract entry in the `agent-config.json` file that had a `proxy` key but no `events` key was not properly handled by the test script.

The intended behavior for contract entries in the test script is the following:
- If it has a `proxy` key but no `events` key, use `return` before attempting to iterate over the `events`
- If it has a `proxy` key and an `events` key, allow execution to continue to the `forEach` over all of the elements in the `events` Object
- If it does not have a `proxy` key, allow execution of the `forEach` which could result in a thrown error if no `events` key is present (this is the desired behavior for warning the user that something is misconfigured)

The logic present in the bot code appears to handle this situation correctly, but the test script did not.